### PR TITLE
exclude google js from minify

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -40,5 +40,13 @@
                 <enabled_create>1</enabled_create>
             </frontend>
         </msp_securitysuite_recaptcha>
+        <dev>
+            <js>
+                <minify_exclude>
+                    google.com
+                    gstatic.com
+                </minify_exclude>
+            </js>
+        </dev>
     </default>
 </config>


### PR DESCRIPTION
this should fix issue #16 (when magento config `dev/js/minify_files` is set to `1`)