### PR TITLE
Ability to set widget language from admin and per/website

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -22,6 +22,7 @@ namespace MSP\ReCaptcha\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Phrase;
+use Magento\Store\Model\ScopeInterface;
 use MSP\ReCaptcha\Model\Config\Source\Type;
 
 class Config
@@ -30,6 +31,7 @@ class Config
     const XML_PATH_ENABLED_FRONTEND = 'msp_securitysuite_recaptcha/frontend/enabled';
 
     const XML_PATH_TYPE_FRONTEND = 'msp_securitysuite_recaptcha/frontend/type';
+    const XML_PATH_LANGUAGE_CODE = 'msp_securitysuite_recaptcha/frontend/lang';
 
     const XML_PATH_POSITION_FRONTEND = 'msp_securitysuite_recaptcha/frontend/position';
 
@@ -229,5 +231,14 @@ class Config
     public function getFrontendType()
     {
         return $this->scopeConfig->getValue(static::XML_PATH_TYPE_FRONTEND);
+    }
+
+    /**
+     * Get language code
+     * @return string
+     */
+    public function getLanguageCode()
+    {
+        return $this->scopeConfig->getValue(static::XML_PATH_LANGUAGE_CODE, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Model/LayoutSettings.php
+++ b/Model/LayoutSettings.php
@@ -49,6 +49,7 @@ class LayoutSettings
             'size' => $this->config->getFrontendSize(),
             'badge' => $this->config->getFrontendPosition(),
             'theme' => $this->config->getFrontendTheme(),
+            'lang' => $this->config->getLanguageCode(),
             'enabled' => [
                 'login' => $this->config->isEnabledFrontendLogin(),
                 'create' => $this->config->isEnabledFrontendCreate(),

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -108,6 +108,18 @@
                         <field id="type">recaptcha</field>
                     </depends>
                 </field>
+                <field id="lang" translate="label" type="text" sortOrder="65" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Language Code</label>
+                    <comment><![CDATA[
+                    <div>
+                        See <strong><a target="_blank" href="https://developers.google.com/recaptcha/docs/language">supported Language codes</a></strong>.
+                    </div>
+                ]]></comment>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
                 <field id="size" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1"
                        showInStore="0" canRestore="1">
                     <label>Size</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -113,6 +113,7 @@
                     <label>Language Code</label>
                     <comment><![CDATA[
                     <div>
+                        Optional. Forces the widget to render in a specific language. Auto-detects the user's language if unspecified.<br />
                         See <strong><a target="_blank" href="https://developers.google.com/recaptcha/docs/language">supported Language codes</a></strong>.
                     </div>
                 ]]></comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -34,6 +34,7 @@
                 <type>standard</type>
                 <position>inline</position>
                 <theme>light</theme>
+                <lang>en</lang>
                 <enabled_login>1</enabled_login>
                 <enabled_forgot>1</enabled_forgot>
                 <enabled_contact>1</enabled_contact>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -34,7 +34,7 @@
                 <type>standard</type>
                 <position>inline</position>
                 <theme>light</theme>
-                <lang>en</lang>
+                <lang></lang>
                 <enabled_login>1</enabled_login>
                 <enabled_forgot>1</enabled_forgot>
                 <enabled_contact>1</enabled_contact>

--- a/view/frontend/web/js/reCaptcha.js
+++ b/view/frontend/web/js/reCaptcha.js
@@ -66,7 +66,7 @@ define(
                 element.async = true;
                 element.src = 'https://www.google.com/recaptcha/api.js'
                     + '?onload=globalOnRecaptchaOnLoadCallback&render=explicit'
-                    + '&hl=' + this.settings.lang;
+                    + (this.settings.lang ? '&hl=' + this.settings.lang : '');
 
                 scriptTag.parentNode.insertBefore(element, scriptTag);
 
@@ -129,7 +129,6 @@ define(
                     'theme': this.settings.theme,
                     'size': this.settings.size,
                     'badge': this.badge ? this.badge : this.settings.badge,
-                    'lang': this.settings.lang,
                     'callback': function (token) { // jscs:ignore jsDoc
                         me.reCaptchaCallback(token);
                     }

--- a/view/frontend/web/js/reCaptcha.js
+++ b/view/frontend/web/js/reCaptcha.js
@@ -22,14 +22,54 @@ define(
         'uiComponent',
         'jquery',
         'ko',
-        'MSP_ReCaptcha/js/registry',
-        'https://www.google.com/recaptcha/api.js'
+        'MSP_ReCaptcha/js/registry'
     ],
-    function (Component, $, ko, registry) {
+    function (Component, $, ko, registry, undefined) {
 
         return Component.extend({
+
             defaults: {
                 template: 'MSP_ReCaptcha/reCaptcha'
+            },
+            _isApiRegistered: undefined,
+
+            initialize: function () {
+              this._super();
+              this._loadApi();
+            },
+
+            /**
+              * Loads recaptchaapi API and triggers event, when loaded
+              * @private
+              */
+            _loadApi: function () {
+                var element, scriptTag;
+
+                if (this._isApiRegistered !== undefined) {
+                    if (this._isApiRegistered === true) {
+                        $(window).trigger('recaptchaapiready');
+                    }
+
+                    return;
+                }
+                this._isApiRegistered = false;
+
+                // global function
+                window.globalOnRecaptchaOnLoadCallback = function() {
+                    this._isApiRegistered = true;
+                    $(window).trigger('recaptchaapiready');
+                }.bind(this);
+
+                element   = document.createElement('script');
+                scriptTag = document.getElementsByTagName('script')[0];
+
+                element.async = true;
+                element.src = 'https://www.google.com/recaptcha/api.js'
+                    + '?onload=globalOnRecaptchaOnLoadCallback&render=explicit'
+                    + '&hl=' + this.settings.lang;
+
+                scriptTag.parentNode.insertBefore(element, scriptTag);
+
             },
 
             /**
@@ -89,6 +129,7 @@ define(
                     'theme': this.settings.theme,
                     'size': this.settings.size,
                     'badge': this.badge ? this.badge : this.settings.badge,
+                    'lang': this.settings.lang,
                     'callback': function (token) { // jscs:ignore jsDoc
                         me.reCaptchaCallback(token);
                     }


### PR DESCRIPTION
We have requirement to set for certain store specific language, no matter of geographical location -
 auto detect on language doesn't fit for our need.

Based on the https://developers.google.com/recaptcha/docs/display it requires to have "`hl=`" parameter while loading the `recaptcha/api.js`.

Added new config field for language code with the link in the comment where are shown supported language code.

Updated also that during the class initialization library is loaded asynchronously with `hl=` parameter.