### PR TITLE
Update dependencies

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -24,6 +24,7 @@
     <module name="MSP_ReCaptcha" setup_version="1.4.11">
         <sequence>
             <module name="MSP_SecuritySuiteCommon"/>
+            <module name="Magento_Customer"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Some code of the module is base on magento customer module, but the dependencies is not declare. This can lead to error on installation if a module depend on this one.